### PR TITLE
react-snapshot fix

### DIFF
--- a/src/components/Home.js
+++ b/src/components/Home.js
@@ -4,11 +4,11 @@ import React, { Component } from 'react';
 import SwipeableViews from 'react-swipeable-views';
 
 import { Tab, Tabs } from 'material-ui/Tabs';
-import withWidth, { LARGE } from 'material-ui/utils/withWidth';
 
 import Shelf from './Shelf';
 
 import type { BookType } from '../common/flowTypes';
+import getWidth, { widths } from '../utils/getWidth';
 
 export class Home extends Component {
 	props: {
@@ -40,7 +40,7 @@ export class Home extends Component {
 			findShelf
 		} = this.props;
 
-		const wide = this.props.width === LARGE;
+		const wide = getWidth() === widths.large;
 
 		const shelfText = {
 			read: {
@@ -107,4 +107,4 @@ export class Home extends Component {
 	}
 }
 
-export default withWidth()(Home);
+export default Home;

--- a/src/components/Landing.js
+++ b/src/components/Landing.js
@@ -4,9 +4,10 @@ import { Link } from 'react-router-dom';
 import styled from 'styled-components';
 
 import RaisedButton from 'material-ui/RaisedButton';
-import withWidth, { LARGE } from 'material-ui/utils/withWidth';
 import typography from 'material-ui/styles/typography';
 import muiThemeable from 'material-ui/styles/muiThemeable';
+
+import getWidth, { widths } from '../utils/getWidth';
 
 const Hero = styled.div`
 	background-color: ${props => props.muiTheme.palette.primary1Color};
@@ -49,7 +50,7 @@ const BookLogo = styled.img`
 
 class Landing extends Component {
 	render() {
-		const wide = this.props.width === LARGE;
+		const wide = getWidth() === widths.large;
 		const muiTheme = this.props.muiTheme;
 
 		return (
@@ -85,4 +86,4 @@ class Landing extends Component {
 	}
 }
 
-export default withWidth()(muiThemeable()(Landing));
+export default muiThemeable()(Landing);

--- a/src/components/Search.js
+++ b/src/components/Search.js
@@ -8,11 +8,11 @@ import Dialog from 'material-ui/Dialog';
 import FlatButton from 'material-ui/FlatButton';
 import FontIcon from 'material-ui/FontIcon';
 import Snackbar from 'material-ui/Snackbar';
-import withWidth, { LARGE } from 'material-ui/utils/withWidth';
 
 import BookList from './BookList';
 
 import { search } from '../utils/BooksAPI';
+import getWidth, { widths } from '../utils/getWidth';
 import type { BookType } from '../common/flowTypes';
 import searchTerms from '../common/searchTerms';
 
@@ -99,7 +99,7 @@ class Search extends Component {
 						filter={AutoComplete.fuzzyFilter}
 						dataSource={searchTerms}
 						textFieldStyle={
-							this.props.width === LARGE
+							getWidth() === widths.large
 								? styles.searchFieldWide
 								: styles.searchField
 						}
@@ -151,4 +151,4 @@ class Search extends Component {
 	}
 }
 
-export default withWidth()(Search);
+export default Search;

--- a/src/utils/getWidth.js
+++ b/src/utils/getWidth.js
@@ -1,0 +1,29 @@
+// @flow
+
+// MUI's withWidth HOC is great, bbut doesn't support server-side rendering. So,
+// I had to ditch it & write my own mediocre width handler so that React-Snapshot
+// will do its thing.
+
+import { SMALL, MEDIUM, LARGE } from 'material-ui/utils/withWidth';
+
+export const widths = { small: SMALL, medium: MEDIUM, large: LARGE };
+
+const getWidth = () => {
+	let width;
+	const largeWidth = 992,
+		mediumWidth = 768;
+
+	const innerWidth = window.innerWidth;
+
+	if (innerWidth >= largeWidth) {
+		width = LARGE;
+	} else if (innerWidth >= mediumWidth) {
+		width = MEDIUM;
+	} else {
+		width = SMALL;
+	}
+
+	return width;
+};
+
+export default getWidth;


### PR DESCRIPTION
react-snapshot was only prerendering my TopBar, because each of my main pages depended on MUI's withWidth HOC, which won't render outside a browser. So I wrote my own (worse) replacement to do the job instead. Not as snazzy as MUI's version, but at least it renders now